### PR TITLE
Fixed the /etc/freekey.conf file when using multiple interfaces

### DIFF
--- a/freekey/freekey.py
+++ b/freekey/freekey.py
@@ -117,11 +117,12 @@ def write_default_conf(fn):
     if os.path.isfile(fn):
         print 'Configuration file %s exists. Skipping file generation.' % fn
     open(fn, 'w').write(r"""#ScanCode Command
+# Note: If you're running Cinnamon, substitute 'gnome-screensaver-command' with 'cinnamon-screensaver-command'
 # volume up/down
 122 gnome-screensaver-command -q | grep "is active" && bash -c '/usr/bin/pactl -- set-sink-volume `pacmd list-sinks | grep -P -o "(?<=\* index: )[0-9]+"` -10%'
 123 gnome-screensaver-command -q | grep "is active" && bash -c '/usr/bin/pactl -- set-sink-volume `pacmd list-sinks | grep -P -o "(?<=\* index: )[0-9]+"` +10%'
 # mute
-121 cinnamon-screensaver-command -q | grep "is active" && bash -c 'for i in $(pacmd list-sinks | grep -Po "(?<=\* index: )[0-9]+"); do /usr/bin/pactl -- set-sink-mute $i $(pacmd list-sinks | grep -Pqzo "(?s)\* index.*?muted: no" && echo 1 || echo 0); done'
+121 gnome-screensaver-command -q | grep "is active" && bash -c 'for i in $(pacmd list-sinks | grep -Po "(?<=\* index: )[0-9]+"); do /usr/bin/pactl -- set-sink-mute $i $(pacmd list-sinks | grep -Pqzo "(?s)\* index.*?muted: no" && echo 1 || echo 0); done'
 # play/pause
 171 gnome-screensaver-command -q | grep "is active" && bash -c '/usr/bin/pactl -- suspend-sink `pacmd list-sinks | grep -P -o "(?<=\* index: )[0-9]+"` `pacmd list-sinks | grep -P -o "state: RUNNING" | wc -l`'
 """)


### PR DESCRIPTION
I made it so the mute command in /etc/freekey.conf loops through the active interfaces to toggle their mute status. I also added a note about Cinnamon vs. Gnome.
